### PR TITLE
Fix case inconsistencies in imports

### DIFF
--- a/src/FeedNim.nim
+++ b/src/FeedNim.nim
@@ -1,8 +1,8 @@
 import httpclient
 
-import feednim/atom
-import feednim/rss
-import feednim/jsonfeed
+import FeedNim/atom
+import FeedNim/rss
+import FeedNim/jsonfeed
 
 proc loadAtom*(filename: string): Atom = ## Loads the Atom from the given ``filename``.
     var Atom: string = readFile(filename) # Load the data from the file.

--- a/tests/test_atom.nim
+++ b/tests/test_atom.nim
@@ -9,8 +9,8 @@ import unittest
 
 import marshal
 
-import feednim
-import ../src/feednim/atom
+import FeedNim
+import ../src/FeedNim/atom
 
 test "Read Valid Atom Feed":
     let feed = "./tests/test_atom.xml".loadAtom()

--- a/tests/test_jsonfeed.nim
+++ b/tests/test_jsonfeed.nim
@@ -9,8 +9,8 @@ import unittest
 
 import marshal
 
-import feednim
-import ../src/feednim/jsonfeed
+import FeedNim
+import ../src/FeedNim/jsonfeed
 
 test "Read Valid JsonFeed":
     let feed = "./tests/test_jsonfeed.json".loadJsonFeed()

--- a/tests/test_rss.nim
+++ b/tests/test_rss.nim
@@ -9,8 +9,8 @@ import unittest
 
 import marshal
 
-import feednim
-import ../src/feednim/Rss
+import FeedNim
+import ../src/FeedNim/rss
 
 test "Read Valid Rss Feed":
     let feed = "./tests/test_rss.xml".loadRss()


### PR DESCRIPTION
After running `nimble install feednim`, I was unable to actually import `FeedNim` into my project: 

```
/home/reesmichael1/.nimble/pkgs/FeedNim-0.2.1/FeedNim.nim(3, 15) Error: cannot open file: feednim/atom
```

This was because `FeedNim.nim` was importing from `feednim` (instead of `FeedNim`). This pull request fixes the case inconsistencies. 

Thanks for a really nice library!