### PR TITLE
Fix crash on feed content shorter than 9 characters

### DIFF
--- a/src/FeedNim/rss.nim
+++ b/src/FeedNim/rss.nim
@@ -101,7 +101,7 @@ func parseText ( node: XmlNode ): string =
     for item in node.items:
         content = content & $item
     # Strip CDATA
-    if content[0 .. 8] == "<![CDATA[":
+    if content.len >= 9 and content[0 .. 8] == "<![CDATA[":
         content = content.substr[9 .. content.len()-4 ]
         return content
     else:

--- a/tests/test_rss.xml
+++ b/tests/test_rss.xml
@@ -54,6 +54,17 @@
 			<guid>http://joe.bloggs/posts/1</guid>
 			<source url="http://dictionary.com">The Dictionary</source>
 		</item>
+		<item>
+			<title>Short</title>
+			<link>http://joe.bloggs/posts/2</link>
+			<pubDate>Sat, 07 Sep 2002 00:00:01 GMT</pubDate>
+			<description><![CDATA[Short]]></description>
+			<author>jane@joe.bloggs (Jane Bloggs)</author>
+			<category domain="http://awesomecategories.org" >Words</category>
+			<comments>http://joe.bloggs/posts/2/comments</comments>
+			<guid>http://joe.bloggs/posts/2</guid>
+			<source url="http://dictionary.com">The Dictionary</source>
+		</item>
 
 	</channel>
 </rss>


### PR DESCRIPTION
Another simple fix! I had a crash when the feed content was shorter than 9 characters because of the check if the first 9 characters matched `<![CDATA[`. 