### PR TITLE
CData handling for Atom feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ Session.vim
 tags
 # Persistent undo
 [._]*.un~
+
+# Test binaries
+tests/test_atom
+tests/test_jsonfeed
+tests/test_rss

--- a/src/FeedNim/atom.nim
+++ b/src/FeedNim/atom.nim
@@ -141,16 +141,16 @@ func parseLink ( node: XmlNode ): AtomLink =
     return link
 
 func parseText ( node: XmlNode ): string =
-    if node.attr("type") == "xhtml" or node.attr("type") == "html":
+    if node.len == 0:
+        return $node
+    else:
         var content = ""
         for item in node.items:
-            content = content & $item
-        # Strip CDATA
-        if content[0 .. 8] == "<![CDATA[":
-            content = content.substr[9 .. content.len()-4 ]
+            case item.kind
+            of xnText: content.add(item.innerText)
+            of xnCData: content.add(item.text)
+            else: discard
         return content
-    else:
-        return node.innerText
 
 func parseEntry( node: XmlNode ) : AtomEntry =
     var entry: AtomEntry = AtomEntry()
@@ -204,7 +204,7 @@ func parseEntry( node: XmlNode ) : AtomEntry =
 
         entry.source.author = entry.source.authors[0]
 
-    if node.child("summary") != nil: entry.summary = node.child("summary").innerText
+    if node.child("summary") != nil: entry.summary = node.child("summary").parseText()
 
     # SUGAR an easy way to access an author
     if entry.authors.len() > 0:

--- a/src/FeedNim/rss.nim
+++ b/src/FeedNim/rss.nim
@@ -97,15 +97,16 @@ func parseCategories( node: XmlNode ): seq[RSSCategory] =
     return categories
 
 func parseText ( node: XmlNode ): string =
-    var content = ""
-    for item in node.items:
-        content = content & $item
-    # Strip CDATA
-    if content[0 .. 8] == "<![CDATA[":
-        content = content.substr[9 .. content.len()-4 ]
-        return content
+    if node.len == 0:
+        return $node
     else:
-        return node.innerText
+        var content = ""
+        for item in node.items:
+            case item.kind
+            of xnText: content.add(item.innerText)
+            of xnCData: content.add(item.text)
+            else: discard
+        return content
 
 func parseItem( node: XmlNode) : RSSItem =
     var item: RSSItem = RSSItem()

--- a/tests/test_atom.nim
+++ b/tests/test_atom.nim
@@ -8,6 +8,7 @@
 import unittest
 
 import marshal
+import strformat
 
 import FeedNim
 import ../src/FeedNim/atom
@@ -66,8 +67,11 @@ test "Read Valid Atom Feed":
     var feed_0_content_textType = feed.entries[0].content.textType
     check feed_0_content_textType == "xhtml"
     var feed_0_content_text: string = feed.entries[0].content
-    check feed_0_content_text == """<div xmlns="http://www.w3.org/1999/xhtml"><p><i>Aero</i>- not air-, fools!</p></div>"""
-
+    check &"!{feed_0_content_text}!" == """!
+            <div xmlns="http://www.w3.org/1999/xhtml">
+                <p><i>Aero</i>- not air-, fools!</p>
+            </div>
+        !"""
     check feed.entries[0].published == "2003-12-13T18:30:02Z"
     check feed.entries[0].rights == "Copyright Joe Bloggs"
 

--- a/tests/test_atom.xml
+++ b/tests/test_atom.xml
@@ -45,11 +45,11 @@
             <email>mail@joe.bloggs</email>
         </author>
         <category term="words" label="Words" scheme="http://awesomecategories.org" />
-        <content type="xhtml">
+        <content type="xhtml"><![CDATA[
             <div xmlns="http://www.w3.org/1999/xhtml">
                 <p><i>Aero</i>- not air-, fools!</p>
             </div>
-        </content>
+        ]]></content>
         <published>2003-12-13T18:30:02Z</published>
         <rights>Copyright Joe Bloggs</rights>
         <source>

--- a/tests/test_jsonfeed.nim
+++ b/tests/test_jsonfeed.nim
@@ -54,7 +54,7 @@ test "Read Valid JsonFeed":
 test "Fetch JsonFeed from JsonFeed.org":
     let feed = getJsonFeed("https://jsonfeed.org/feed.json")
     check feed.title != ""
-    check feed.home_page_url == "https://jsonfeed.org/"
-    check feed.items[0].title == "Announcing JSON Feed"
+    check feed.home_page_url == "https://www.jsonfeed.org/"
+    check feed.items[0].title == "JSON Feed version 1.1"
     check feed.items[0].date_published != ""
     check feed.items[0].id != ""


### PR DESCRIPTION
Hello good sir.

I believe I've addressed the CData handling of the parseText() functions in the atom and rss modules. It turns out that a xnCData type of XmlNode has no innerText(), only text()

This resolves #7 